### PR TITLE
Maintain multiple path handlers

### DIFF
--- a/cmd/k8s-svc-proxy/static/error_404.html
+++ b/cmd/k8s-svc-proxy/static/error_404.html
@@ -1,0 +1,20 @@
+<html lang="en">
+    <head>
+      <meta name="viewport" content="width=device-width, initial-scale=1">
+      <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7" crossorigin="anonymous">
+    </head>
+    <body>
+        <div class="container">
+            <div class="row">
+                <div class="span12">
+                <div class="jumbotron center">
+                    <h1>Page Not Found <small><font face="Tahoma" color="red">Error 404</font></small></h1>
+                    <br />
+                    <p>The page you requested could not be found.</p>
+                    <a href="k8s-svc-proxy/status.html" class="btn btn-large btn-info"><i class="icon-home icon-white"></i>Status</a>
+                </div>
+                </div>
+            </div>
+        </div>
+    </body>
+</html>


### PR DESCRIPTION
Multiple services can point at the same path simultaneously; keep a list of registered handlers per path.
Serve an error page when the URL is not found. Auto-redirect forces the user
to type the path again on a typo.